### PR TITLE
Add container creation button and fix quick add

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -85,6 +85,11 @@ export function Layout() {
               備品追加
             </Button>
           </NavbarItem>
+          <NavbarItem className="hidden sm:flex">
+            <Button as={Link} color="primary" to="/containers/new" variant="flat" size="sm">
+              コンテナ追加
+            </Button>
+          </NavbarItem>
         </NavbarContent>
 
         <NavbarMenu>
@@ -105,16 +110,27 @@ export function Layout() {
                 <span className="text-sm text-foreground-500">接続状態:</span>
                 <ConnectionStatus />
               </div>
-              <Button 
-                as={Link} 
-                color="primary" 
-                to="/items/new" 
-                variant="flat" 
+              <Button
+                as={Link}
+                color="primary"
+                to="/items/new"
+                variant="flat"
                 size="sm"
                 className="w-full"
                 onClick={() => setIsMenuOpen(false)}
               >
                 備品追加
+              </Button>
+              <Button
+                as={Link}
+                color="primary"
+                to="/containers/new"
+                variant="flat"
+                size="sm"
+                className="w-full"
+                onClick={() => setIsMenuOpen(false)}
+              >
+                コンテナ追加
               </Button>
             </div>
           </NavbarMenuItem>

--- a/src/pages/containers/ContainersList.tsx
+++ b/src/pages/containers/ContainersList.tsx
@@ -657,7 +657,8 @@ function ContainerInlineCreatorRow({
         <Button
           size="sm"
           color="primary"
-          onPress={() => {
+          type="button"
+          onClick={() => {
             console.log('Save button clicked', { 
               name: name.trim(), 
               location: location.trim(), 
@@ -681,7 +682,8 @@ function ContainerInlineCreatorRow({
       color="default"
       className="w-full justify-start p-2"
       startContent={<Plus size={16} />}
-      onPress={() => setIsCreating(true)}
+      type="button"
+      onClick={() => setIsCreating(true)}
     >
       新規コンテナ作成...
     </Button>


### PR DESCRIPTION
## Summary
- fix container inline creation button using standard click events
- add container creation button beside existing item add buttons in the navbar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68b7fc3ad120832b963c59b36480b9b5