### PR TITLE
Fix container creation validation

### DIFF
--- a/src/pages/containers/ContainerForm.tsx
+++ b/src/pages/containers/ContainerForm.tsx
@@ -219,22 +219,29 @@ export function ContainerForm() {
               value={formValues.name || ''}
               onValueChange={(v) => setValue('name', v)}
             />
-            <Autocomplete
-              label="場所"
-              placeholder="場所を入力または選択"
-              allowsCustomValue
-              isRequired
-              isInvalid={!!errors.location}
-              errorMessage={errors.location?.message}
-              value={formValues.location || ''}
-              onValueChange={v => setValue('location', v)}
-            >
-              {locationSuggestions.map(loc => (
-                <AutocompleteItem key={loc}>
-                  {loc}
-                </AutocompleteItem>
-              ))}
-            </Autocomplete>
+            <Controller
+              name="location"
+              control={control}
+              rules={{ required: '場所は必須です' }}
+              render={({ field, fieldState }) => (
+                <Autocomplete
+                  label="場所"
+                  placeholder="場所を入力または選択"
+                  allowsCustomValue
+                  isRequired
+                  isInvalid={!!fieldState.error}
+                  errorMessage={fieldState.error?.message}
+                  value={field.value || ''}
+                  onValueChange={field.onChange}
+                >
+                  {locationSuggestions.map(loc => (
+                    <AutocompleteItem key={loc}>
+                      {loc}
+                    </AutocompleteItem>
+                  ))}
+                </Autocomplete>
+              )}
+            />
             <Textarea
               {...register('description')}
               label="説明"

--- a/src/pages/containers/ContainersList.tsx
+++ b/src/pages/containers/ContainersList.tsx
@@ -624,7 +624,7 @@ function ContainerInlineCreatorRow({
             onValueChange={setId}
             onKeyDown={handleKeyDown}
             size="sm"
-            disabled={isSaving}
+            isDisabled={isSaving}
           />
         </div>
         <Input
@@ -636,7 +636,7 @@ function ContainerInlineCreatorRow({
           onKeyDown={handleKeyDown}
           size="sm"
           className="flex-grow"
-          disabled={isSaving}
+          isDisabled={isSaving}
         />
         <div className="w-48">
           <Autocomplete
@@ -647,7 +647,7 @@ function ContainerInlineCreatorRow({
             onValueChange={setLocation}
             onKeyDown={handleKeyDown}
             size="sm"
-            disabled={isSaving}
+            isDisabled={isSaving}
           >
             {locationSuggestions.map(loc => (
               <AutocompleteItem key={loc}>{loc}</AutocompleteItem>
@@ -659,16 +659,16 @@ function ContainerInlineCreatorRow({
           color="primary"
           type="button"
           onClick={() => {
-            console.log('Save button clicked', { 
-              name: name.trim(), 
-              location: location.trim(), 
+            console.log('Save button clicked', {
+              name: name.trim(),
+              location: location.trim(),
               disabled: !name.trim() || !location.trim(),
-              isSaving 
+              isSaving
             })
             handleSave()
           }}
           isLoading={isSaving}
-          disabled={!name.trim() || !location.trim()}
+          isDisabled={!name.trim() || !location.trim()}
         >
           Save
         </Button>


### PR DESCRIPTION
## Summary
- register location field in container form with react-hook-form
- use `isDisabled` for quick-add inputs and button so save triggers correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68bab687b770832bbdc1e1874b634887