### PR TITLE
fix: enable container creation and require manual label

### DIFF
--- a/src/components/ui/SingleLocationInput.tsx
+++ b/src/components/ui/SingleLocationInput.tsx
@@ -9,6 +9,16 @@ interface SingleLocationInputProps {
   suggestions?: string[]
   isReadOnly?: boolean
   description?: string
+  /** 表示をエラー状態にする */
+  isInvalid?: boolean
+  /** エラーメッセージ */
+  errorMessage?: string
+  /** 必須入力フラグ */
+  isRequired?: boolean
+  /** サイズ指定 */
+  size?: 'sm' | 'md' | 'lg'
+  /** 入力不可状態 */
+  isDisabled?: boolean
 }
 
 export const SingleLocationInput: React.FC<SingleLocationInputProps> = ({
@@ -19,6 +29,11 @@ export const SingleLocationInput: React.FC<SingleLocationInputProps> = ({
   suggestions = [],
   isReadOnly = false,
   description,
+  isInvalid = false,
+  errorMessage,
+  isRequired = false,
+  size = 'md',
+  isDisabled = false,
 }) => {
   const [inputValue, setInputValue] = useState(value || '')
 
@@ -48,6 +63,11 @@ export const SingleLocationInput: React.FC<SingleLocationInputProps> = ({
       allowsCustomValue
       className="w-full"
       variant="bordered"
+      isInvalid={isInvalid}
+      errorMessage={errorMessage}
+      isRequired={isRequired}
+      size={size}
+      isDisabled={isDisabled}
       defaultItems={suggestions.map(s => ({ value: s, label: s }))}
     >
       {(item) => <AutocompleteItem key={item.value}>{item.label}</AutocompleteItem>}

--- a/src/pages/containers/ContainersList.tsx
+++ b/src/pages/containers/ContainersList.tsx
@@ -81,6 +81,7 @@ import { ContainerWithItemCount } from '@/services'
 import { EnhancedList, ColumnDef } from '@/components/ui/EnhancedList'
 import { EditableCell } from '@/components/ui/EditableCell'
 import { ContainerBulkActionBar } from '@/components/ui/ContainerBulkActionBar'
+import { SingleLocationInput } from '@/components/ui/SingleLocationInput'
 
 // dnd-kit imports
 import {
@@ -535,7 +536,7 @@ export function ContainersList() {
           onSave={async ({ id, name, location }) => {
             console.log('onSave callback called with:', { id, name, location })
             try {
-              const payload = { ...(id && { id }), name, location }
+              const payload = { id, name, location }
               console.log('Calling createContainerMutation with:', payload)
               const result = await createContainerMutation.mutateAsync(payload)
               console.log('createContainerMutation completed:', result)
@@ -563,7 +564,7 @@ function ContainerInlineCreatorRow({
   onSave,
 }: {
   locationSuggestions: string[],
-  onSave: (value: { id?: string; name: string; location: string }) => Promise<void>
+  onSave: (value: { id: string; name: string; location: string }) => Promise<void>
 }) {
   const [isCreating, setIsCreating] = useState(false)
   const [id, setId] = useState('')
@@ -573,19 +574,12 @@ function ContainerInlineCreatorRow({
 
   const handleSave = async () => {
     console.log('handleSave called', { name: name.trim(), location: location.trim(), id: id.trim() })
-    if (name.trim() && location.trim()) {
+    if (id.trim() && name.trim() && location.trim()) {
       setIsSaving(true)
       try {
-        console.log('Calling onSave with:', {
-          ...(id.trim() ? { id: id.trim() } : {}),
-          name: name.trim(),
-          location: location.trim(),
-        })
-        await onSave({
-          ...(id.trim() ? { id: id.trim() } : {}),
-          name: name.trim(),
-          location: location.trim(),
-        })
+        const payload = { id: id.trim(), name: name.trim(), location: location.trim() }
+        console.log('Calling onSave with:', payload)
+        await onSave(payload)
         console.log('onSave completed successfully')
         setId('')
         setName('')
@@ -598,7 +592,7 @@ function ContainerInlineCreatorRow({
         setIsSaving(false)
       }
     } else {
-      console.log('Validation failed', { name: name.trim(), location: location.trim() })
+      console.log('Validation failed', { id: id.trim(), name: name.trim(), location: location.trim() })
     }
   }
 
@@ -619,7 +613,7 @@ function ContainerInlineCreatorRow({
         <div className="w-32">
           <Input
             aria-label="Container ID"
-            placeholder="ID (任意)"
+            placeholder="ID"
             value={id}
             onValueChange={setId}
             onKeyDown={handleKeyDown}
@@ -639,20 +633,15 @@ function ContainerInlineCreatorRow({
           isDisabled={isSaving}
         />
         <div className="w-48">
-          <Autocomplete
+          <SingleLocationInput
             label="場所"
             placeholder="場所を入力または選択"
-            allowsCustomValue
             value={location}
-            onValueChange={setLocation}
-            onKeyDown={handleKeyDown}
+            onChange={setLocation}
+            suggestions={locationSuggestions}
             size="sm"
             isDisabled={isSaving}
-          >
-            {locationSuggestions.map(loc => (
-              <AutocompleteItem key={loc}>{loc}</AutocompleteItem>
-            ))}
-          </Autocomplete>
+          />
         </div>
         <Button
           size="sm"
@@ -660,15 +649,16 @@ function ContainerInlineCreatorRow({
           type="button"
           onClick={() => {
             console.log('Save button clicked', {
+              id: id.trim(),
               name: name.trim(),
               location: location.trim(),
-              disabled: !name.trim() || !location.trim(),
+              disabled: !id.trim() || !name.trim() || !location.trim(),
               isSaving
             })
             handleSave()
           }}
           isLoading={isSaving}
-          isDisabled={!name.trim() || !location.trim()}
+          isDisabled={!id.trim() || !name.trim() || !location.trim()}
         >
           Save
         </Button>


### PR DESCRIPTION
## Summary
- require manual container label ID and remove auto-generation
- fix location inputs using reusable SingleLocationInput with validation support
- ensure quick-add row enables save button only when all fields filled

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run type-check` *(fails: multiple TS errors: Cannot find module 'react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68babb8cf094832bb65b6bb7021a708b